### PR TITLE
fix: update valid default size types for item-info component

### DIFF
--- a/src/components/item-info/index.js
+++ b/src/components/item-info/index.js
@@ -58,7 +58,7 @@ ItemInfo.propTypes = {
     publisher: PropTypes.string,
     language: PropTypes.string,
     cover: PropTypes.string,
-    size: PropTypes.string, // normal | large
+    size: PropTypes.oneOf(['normal', 'large']),
     className: PropTypes.string,
     style: PropTypes.object,
 };


### PR DESCRIPTION
<!-- Please begin the title with `type: [ imperative message ]` -->

fix: update valid default size types for item-info component

@nexxtway/rainbow-algolia-search
