### PR TITLE
fix: surround arrow element inside back-link

### DIFF
--- a/src/components/back-link/index.js
+++ b/src/components/back-link/index.js
@@ -11,7 +11,7 @@ const BackLink = props => {
     return (
         <RenderIf isTrue={hasUrl}>
             <Wrapper className={className} style={style}>
-                <Link href={url}>
+                <Link to={url}>
                     <ArrowImg />
                     Back
                 </Link>

--- a/src/components/back-link/index.js
+++ b/src/components/back-link/index.js
@@ -11,8 +11,10 @@ const BackLink = props => {
     return (
         <RenderIf isTrue={hasUrl}>
             <Wrapper className={className} style={style}>
-                <ArrowImg />
-                <Link href={url}>Back</Link>
+                <Link href={url}>
+                    <ArrowImg />
+                    Back
+                </Link>
             </Wrapper>
         </RenderIf>
     );

--- a/src/components/back-link/styled.js
+++ b/src/components/back-link/styled.js
@@ -4,19 +4,17 @@ import BackArrowIcon from '../icons/back-arrow';
 export const Wrapper = styled.div`
     margin-bottom: 43px;
     width: 100%;
-    display: flex;
-    justify-content: flex-start;
-    align-items: center;
 `;
 
 export const Link = styled.a`
-    margin-left: 10px;
-    text-decoration: none;
     font-size: 24px;
     line-height: 1em;
     color: #44d7b6;
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
 
-    :hover {
+    &:hover {
         text-decoration: none;
         color: #44d7b6;
     }
@@ -27,6 +25,7 @@ export const Link = styled.a`
 `;
 
 export const ArrowImg = styled(BackArrowIcon)`
+    margin-right: 10px;
     width: 26px;
 
     @media screen and (max-width: 991px) {

--- a/src/components/back-link/styled.js
+++ b/src/components/back-link/styled.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { Link as RouterLink } from 'react-router-dom';
 import BackArrowIcon from '../icons/back-arrow';
 
 export const Wrapper = styled.div`
@@ -6,7 +7,7 @@ export const Wrapper = styled.div`
     width: 100%;
 `;
 
-export const Link = styled.a`
+export const Link = styled(RouterLink)`
     font-size: 24px;
     line-height: 1em;
     color: #44d7b6;


### PR DESCRIPTION
<!-- Please begin the title with `type: [ imperative message ]` -->

fix: surround arrow element inside back-link

@nexxtway/rainbow-algolia-search
