### PR TITLE
fix: hide result header when don't find matches

### DIFF
--- a/src/pages/home/index.js
+++ b/src/pages/home/index.js
@@ -39,7 +39,9 @@ const Home = () => {
                     />
                     <RecentItem />
                     <DisplayIfQueryInput>
-                        <SearchResultsDescription />
+                        <DisplayIfResults>
+                            <SearchResultsDescription />
+                        </DisplayIfResults>
                     </DisplayIfQueryInput>
 
                     <DisplayIfQueryInput>


### PR DESCRIPTION
fix: #39 

## Changes proposed in this PR:
- Hide result header when don't find matches

@nexxtway/rainbow-algolia-search
